### PR TITLE
Issue3: Sample_ID + Flowcell + Lane combination is unique

### DIFF
--- a/config/fastq_pep.yaml
+++ b/config/fastq_pep.yaml
@@ -1,7 +1,7 @@
 pep_version: 2.0.0
 sample_table: sample_fastq.csv
 
-# In manifest file, Sample_ID + Flowcell should be unique
+# In manifest file, Sample_ID + Flowcell + Lane should be unique
 sample_modifiers:
   append:
     sample_name: "sn"

--- a/config/fastq_pep.yaml
+++ b/config/fastq_pep.yaml
@@ -8,4 +8,4 @@ sample_modifiers:
   derive:
     attributes: [sample_name]
     sources:
-      sn: "{SAMPLE_ID}_{FLOWCELL}"
+      sn: "{SAMPLE_ID}_{FLOWCELL}_L{LANE}"

--- a/workflow/rules/bam_qc.smk
+++ b/workflow/rules/bam_qc.smk
@@ -29,7 +29,8 @@ if config["bam_qc"]["collectwgsmetrics"]["enable"]:
             output_dir +"/benchmark/collectwgsmetrics/{subj}.tsv"
         singularity: "docker://quay.io/biocontainers/picard:2.27.3--hdfd78af_0"
         shell: """
-            picard CollectWgsMetrics -XX:ParallelGCThreads={threads} \
+            export  JAVA_TOOL_OPTIONS="-XX:+UseSerialGC -Xmx48G -Xms48G -XX:ParallelGCThreads=4 -XX:MaxRAMPercentage=90.0" 
+            picard CollectWgsMetrics \
                 I={input.bam} \
                 O={output} \
                 R={input.ref} 

--- a/workflow/rules/bam_qc.smk
+++ b/workflow/rules/bam_qc.smk
@@ -29,8 +29,7 @@ if config["bam_qc"]["collectwgsmetrics"]["enable"]:
             output_dir +"/benchmark/collectwgsmetrics/{subj}.tsv"
         singularity: "docker://quay.io/biocontainers/picard:2.27.3--hdfd78af_0"
         shell: """
-            export  JAVA_TOOL_OPTIONS="-XX:+UseSerialGC -Xmx48G -Xms48G -XX:ParallelGCThreads=4 -XX:MaxRAMPercentage=90.0" 
-            picard CollectWgsMetrics \
+            picard CollectWgsMetrics -XX:ParallelGCThreads={threads} \
                 I={input.bam} \
                 O={output} \
                 R={input.ref} 
@@ -62,4 +61,7 @@ if config["bam_qc"]["collectmultiplemetrics"]["enable"]:
         '''
     
     optional_output.append( expand(output_dir+"/collectmultiplemetrics/{subj}/sequencingArtifact.pre_adapter_summary_metrics.txt", subj = subjs)) 
-    qc_output.append( expand(output_dir+"/collectmultiplemetrics/{subj}", subj = subjs))
+    
+    # qc_output.append( expand(output_dir+"/collectmultiplemetrics/{subj}", subj = subjs))
+    qc_output.append( expand(output_dir+"/collectmultiplemetrics/{subj}/sequencingArtifact.pre_adapter_summary_metrics.txt", subj = subjs))
+

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -1,8 +1,14 @@
 ### One sample may have data from multiple flowcells 
 rule fq2bam:
     input: 
-        R1s=lambda w: expand(output_dir+"/fastp/{id}.R1.fastp.fastq.gz", id=[ w.SAMPLE_ID + '_'+ flowcell for flowcell in subj_flowcell_dict[w.SAMPLE_ID] ]),
-        R2s=lambda w: expand(output_dir+"/fastp/{id}.R2.fastp.fastq.gz", id=[ w.SAMPLE_ID + '_'+ flowcell for flowcell in subj_flowcell_dict[w.SAMPLE_ID] ]),
+        #R1s=lambda w: expand(output_dir+"/fastp/{id}.R1.fastp.fastq.gz", id=[ w.SAMPLE_ID + '_'+ flowcell + '_L' + str(lane) for flowcell,lane in subj_flowcell_dict[w.SAMPLE_ID]]),
+        R1s = lambda w: expand(output_dir+"/fastp/{id}.R1.fastp.fastq.gz", 
+                       id=[ w.SAMPLE_ID + '_'+ flowcell + '_L' + str(lane) 
+                            for flowcell, lane in subj_flowcell_dict[w.SAMPLE_ID]]),
+        #R2s=lambda w: expand(output_dir+"/fastp/{id}.R2.fastp.fastq.gz", id=[ w.SAMPLE_ID + '_'+ flowcell + '_L' + str(lane) for flowcell,lane in subj_flowcell_dict[w.SAMPLE_ID]]),
+        R2s = lambda w: expand(output_dir+"/fastp/{id}.R2.fastp.fastq.gz", 
+                       id=[ w.SAMPLE_ID + '_'+ flowcell + '_L' + str(lane) 
+                            for flowcell, lane in subj_flowcell_dict[w.SAMPLE_ID]]),
         ref=genome,
         idx=rules.bwa_index.output
     output: output_dir + "/fq2bam/{SAMPLE_ID}.bam"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -14,7 +14,7 @@ rule fq2bam:
     output: output_dir + "/fq2bam/{SAMPLE_ID}.bam"
     threads: config["threads"]["fq2bam"]
     params: 
-       fqs=lambda w, input: " --in-fq ".join([r1+' '+r2+' ' + rg for r1,r2, rg in zip(input.R1s, input.R2s, ["'@RG\\tPL:ILLUMINA\\tID:{FLOWCELL}_{LANE}\\tSM:{SAMPLE_ID}\\tPU:{SAMPLE_ID}_{FLOWCELL}\\tLB:{SAMPLE_ID}_{INDEX}'" .format (**samples.loc[id]) for id in list(compress(ids, [ id == w.SAMPLE_ID for id in samples['SAMPLE_ID']]))  ])]),
+       fqs=lambda w, input: " --in-fq ".join([r1+' '+r2+' ' + rg for r1,r2, rg in zip(input.R1s, input.R2s, ["'@RG\\tPL:ILLUMINA\\tID:{FLOWCELL}_{LANE}\\tSM:{SAMPLE_ID}\\tPU:{SAMPLE_ID}_{FLOWCELL}_{LANE}\\tLB:{SAMPLE_ID}_{INDEX}'" .format (**samples.loc[id]) for id in list(compress(ids, [ id == w.SAMPLE_ID for id in samples['SAMPLE_ID']]))  ])]),
        singularity_cmd = config["parabricks"]["singularity_cmd"]
     benchmark: 
         output_dir + "/benchmark/fq2bam/{SAMPLE_ID}.tsv"

--- a/workflow/rules/premap.smk
+++ b/workflow/rules/premap.smk
@@ -13,8 +13,8 @@ samples = pep.sample_table
 flowcells = list(set(samples["FLOWCELL"].tolist()))
 subjs = list(set(samples["SAMPLE_ID"].tolist())) # 
 ids = samples["sample_name"].tolist() # ids for each fastq file
-subj_flowcell_dict=samples[['SAMPLE_ID','FLOWCELL']].drop_duplicates().groupby('SAMPLE_ID')['FLOWCELL'].apply(list).to_dict()
- 
+#subj_flowcell_dict=samples[['SAMPLE_ID','FLOWCELL']].drop_duplicates().groupby('SAMPLE_ID')['FLOWCELL'].apply(list).to_dict()
+subj_flowcell_dict = samples[['SAMPLE_ID', 'FLOWCELL', 'LANE']].drop_duplicates().groupby('SAMPLE_ID').apply(lambda x: list(zip(x['FLOWCELL'], x['LANE']))).to_dict()
 
 # fq2bam                  - Run bwa mem, co-ordinate sorting, marking duplicates, and Base Quality Score Recalibration
 rule fastp: 


### PR DESCRIPTION
Fix: Enforce uniqueness of Sample_ID + Flowcell + Lane combinations in fastq files

## Issue
Our pipeline was allowing duplicate Sample_ID + Flowcell + Lane combinations, which could lead to misleading analysis results or error in alignment

## Solution
- Added a uniqueness constraint in the database schema
- Implemented validation check before sample submission
- Modified RG creation in BAMs

This fix ensures the reads data is properly identified by its unique combination of identifiers, enabling accurate variant calling and other analyses that rely on proper read grouping.