### PR TITLE
use docker protocol instead of singularity library

### DIFF
--- a/workflow/rules/dnSV.smk
+++ b/workflow/rules/dnSV.smk
@@ -11,7 +11,7 @@ rule manta_create_run_script:
         output_dir + '/manta/{subj}/runWorkflow.py.config.pickle'
     params:
         prefix = output_dir + '/manta/{subj}'
-    singularity: 'library://weizhu365/mocca-sv/manta_1-4-0:1.0.0'
+    singularity: 'docker://halllab/manta:v1.4.0'
     shell:
         'configManta.py \
             --bam {input.bam} \
@@ -29,7 +29,7 @@ rule manta_call:
     threads: config["threads"]["manta_call"]
     benchmark:
         "benchmarks/manta_call/{sample}.tsv"
-    singularity: 'library://weizhu365/mocca-sv/manta_1-4-0:1.0.0'
+    singularity: 'docker://halllab/manta:v1.4.0'
     shell:
         '{input.cmd} -m local -j {threads}'
 


### PR DESCRIPTION
Description
This PR replaces all Singularity library:// URI references with docker:// equivalents to ensure compatibility with Apptainer. After the fork from Singularity, Apptainer has shown inconsistent support for the library:// protocol, while docker:// is fully supported and more reliable.

Changes
Replaced all library:// URIs with their docker:// equivalents

Related Issues
Resolves https://github.com/NCI-CGR/TriosCompass_v2/issues/6
