### PR TITLE
Upgrade Snakemake to 7.8.5

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - snakemake==7.3.7
+  - snakemake==7.8.5
   - snakemake-wrapper-utils
   - pip==22.3.1
   - python==3.10.6
@@ -14,4 +14,4 @@ dependencies:
     - eido==0.1.9
     - peds==1.3.2
     - peppy==0.35.4
-    
+


### PR DESCRIPTION
## Issue
Resolves issue #7 regarding compatibility problems with the workflow when using older versions of Snakemake.

## Changes Made
- Updated Snakemake dependency to version 7.8.5

## Details
To use Apptainer with a symbolic link to Singularity, Snakemake version 7.8.3 or higher. For the workflow to successfully use conda environments in specific tasks, we also need non-strict channel priorities, https://github.com/snakemake/snakemake/pull/1752. Therefore, we need to have Snakemake >7.8.4

## Testing
The workflow has been tested with Snakemake 7.8.5 using our standard test datasets and all steps execute correctly.  