### PR TITLE
Add memory requirements to GATK CombineGVCFs step

### DIFF
--- a/workflow/rules/gatk_hc.smk
+++ b/workflow/rules/gatk_hc.smk
@@ -36,9 +36,10 @@ rule gatk_combine_gvcf:
     benchmark:
         output_dir + "/benchmark/gatk_combine_gvcf/{fam}.tsv"
     params: 
-        v=lambda w, input: " -V ".join(input.vcfs)
+        v=lambda w, input: " -V ".join(input.vcfs),
+        adjusted_mem=lambda wildcards, resources: int((resources.mem_mb / 1024) - 4)
     shell: """
-        gatk CombineGVCFs \
+        gatk --java-options "-Xmx{params.adjusted_mem}G" CombineGVCFs \
             -V {params.v} \
             -R {input.ref} \
             -O {output} 


### PR DESCRIPTION
# Add memory requirements to GATK CombineGVCFs step

## Problem
The workflow was failing when running GATK CombineGVCFs on larger datasets due to insufficient memory allocation. Without explicit memory requirements:
- Jobs would terminate with out-of-memory errors
- Processing became extremely slow due to memory swapping
- Pipeline reliability was compromised

## Solution
This PR:
- Adds configurable memory requirements to the CombineGVCFs step

Closes https://github.com/NCI-CGR/TriosCompass_v2/issues/10